### PR TITLE
Fix tablet subtitle alignement + QuickShelf refinement

### DIFF
--- a/dist/homeii-music-flow.js
+++ b/dist/homeii-music-flow.js
@@ -11712,7 +11712,7 @@ class HomeiiBaseMusicCard extends HTMLElement {
     const el = this.$("npSub");
     if (!el) return;
     const text = String(value || "—");
-    const shouldScroll = !!scrollWhenOverflow && !this._isHebrew();
+    const shouldScroll = this._nowPlayingSubtitleShouldScroll(scrollWhenOverflow);
     const existingInner = el.querySelector?.(".scrolling-text-inner");
     const unchanged = el.dataset.homeiiSubtitleText === text
       && el.dataset.homeiiSubtitleScroll === String(shouldScroll)
@@ -11746,6 +11746,10 @@ class HomeiiBaseMusicCard extends HTMLElement {
     }
     el.appendChild(inner);
     if (shouldScroll) this._queueNowPlayingSubtitleOverflowSync(el);
+  }
+
+  _nowPlayingSubtitleShouldScroll(scrollWhenOverflow = false) {
+    return !!scrollWhenOverflow && !this._isHebrew() && !this._performanceUltraLiteEnabled();
   }
 
   _queueNowPlayingSubtitleOverflowSync(el) {
@@ -27167,6 +27171,11 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
           width:min(1040px, calc(100% - clamp(320px, 24cqi, 440px)));
           margin-left:clamp(300px, 22cqi, 420px);
           margin-right:auto;
+          padding-inline:max(var(--empty-quick-edge-fade), calc(50% - 452px));
+          scroll-padding-inline:max(var(--empty-quick-edge-fade), calc(50% - 452px));
+        }
+        .card.layout-tablet.empty-media .empty-quick-card {
+          scroll-snap-align:start;
         }
         .card.radio-media .empty-quick-shelf {
           display:none !important;
@@ -34531,6 +34540,11 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
 .card.performance-lite .eq-icon span{
   animation:none!important;
   transform:none!important;
+}
+.card.performance-ultra-lite .np-sub.scroll-when-overflow.is-overflowing .scrolling-text-inner{
+  animation:none!important;
+  transform:none!important;
+  will-change:auto!important;
 }
 .performance-profile-pills .settings-pill{
   flex:1 1 96px;

--- a/src/homeii-music-flow.js
+++ b/src/homeii-music-flow.js
@@ -11712,7 +11712,7 @@ class HomeiiBaseMusicCard extends HTMLElement {
     const el = this.$("npSub");
     if (!el) return;
     const text = String(value || "—");
-    const shouldScroll = !!scrollWhenOverflow && !this._isHebrew();
+    const shouldScroll = this._nowPlayingSubtitleShouldScroll(scrollWhenOverflow);
     const existingInner = el.querySelector?.(".scrolling-text-inner");
     const unchanged = el.dataset.homeiiSubtitleText === text
       && el.dataset.homeiiSubtitleScroll === String(shouldScroll)
@@ -11746,6 +11746,10 @@ class HomeiiBaseMusicCard extends HTMLElement {
     }
     el.appendChild(inner);
     if (shouldScroll) this._queueNowPlayingSubtitleOverflowSync(el);
+  }
+
+  _nowPlayingSubtitleShouldScroll(scrollWhenOverflow = false) {
+    return !!scrollWhenOverflow && !this._isHebrew() && !this._performanceUltraLiteEnabled();
   }
 
   _queueNowPlayingSubtitleOverflowSync(el) {
@@ -27167,6 +27171,11 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
           width:min(1040px, calc(100% - clamp(320px, 24cqi, 440px)));
           margin-left:clamp(300px, 22cqi, 420px);
           margin-right:auto;
+          padding-inline:max(var(--empty-quick-edge-fade), calc(50% - 452px));
+          scroll-padding-inline:max(var(--empty-quick-edge-fade), calc(50% - 452px));
+        }
+        .card.layout-tablet.empty-media .empty-quick-card {
+          scroll-snap-align:start;
         }
         .card.radio-media .empty-quick-shelf {
           display:none !important;
@@ -34531,6 +34540,11 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
 .card.performance-lite .eq-icon span{
   animation:none!important;
   transform:none!important;
+}
+.card.performance-ultra-lite .np-sub.scroll-when-overflow.is-overflowing .scrolling-text-inner{
+  animation:none!important;
+  transform:none!important;
+  will-change:auto!important;
 }
 .performance-profile-pills .settings-pill{
   flex:1 1 96px;

--- a/tests/voice-assistant-matching.test.js
+++ b/tests/voice-assistant-matching.test.js
@@ -100,6 +100,20 @@ describe("Music Assistant player filtering", () => {
   });
 });
 
+describe("now playing subtitle", () => {
+  it("disables subtitle scrolling in Ultra Lite performance mode", () => {
+    const card = createCard();
+    card._state.lang = "en";
+    card._state.performanceProfile = "full";
+
+    expect(card._nowPlayingSubtitleShouldScroll(true)).toBe(true);
+
+    card._state.performanceProfile = "ultra_lite";
+
+    expect(card._nowPlayingSubtitleShouldScroll(true)).toBe(false);
+  });
+});
+
 describe("voice assistant music matching", () => {
   it("rejects unrelated search results instead of auto-playing by media type only", () => {
     const card = createCard();


### PR DESCRIPTION
## Summary

This PR refines the now-playing subtitle behavior across tablet, mobile, and RTL layouts.

## Changes

**Now-Playing/Subtitle**

- Aligns the now-playing subtitle with the title in tablet view, including the empty-media state.
- Adjusts the subtitle scrolling animation so it only runs when the subtitle actually overflows.
- Keeps the scrolling animation active in tablet performance mode where it was previously disabled.
- Resyncs subtitle overflow measurements after tablet soft-resize updates.
- Fixes subtitle truncation behavior for Hebrew/RTL by avoiding the LTR scrolling treatment there.
- Keeps UI alignment and spacing consistent across LTR/RTL layouts.

**QuickShelf**

- Adds a soft edge fade to `#emptyQuickShelf` so the horizontal scroll area feels less abruptly clipped.
- Keeps the first visible item clear of the fade at the initial scroll position in both LTR and RTL layouts.
- Softens the fade gradient with a wider transition and intermediate opacity stops.
- Preserves compact layout spacing while keeping the edge fade consistent.

## Testing

- npm run build successful 
- Verified generated `dist/homeii-music-flow.js` is updated.

Before
<img width="1733" height="1090" alt="Capture d’écran, le 2026-05-25 à 09 07 27" src="https://github.com/user-attachments/assets/91bc3409-f8ae-4417-9aee-26b5577a34f5" />
After
<img width="1733" height="1090" alt="Capture d’écran, le 2026-05-25 à 09 46 42" src="https://github.com/user-attachments/assets/d6f93aee-4053-4d18-8d24-3f94ad42f5ce" />
Before
<img width="1733" height="1090" alt="Capture d’écran, le 2026-05-25 à 09 07 44" src="https://github.com/user-attachments/assets/3c723482-fbb6-43bd-8706-398691ce1f4b" />
After
<img width="1733" height="1090" alt="Capture d’écran, le 2026-05-25 à 09 47 06" src="https://github.com/user-attachments/assets/ebacb96b-d171-4cb7-a960-b13d610558b0" />

Mobile view showing QuickShelf fade-out
<img width="1080" height="2340" alt="Screenshot_20260525_095522_Home Assistant" src="https://github.com/user-attachments/assets/f0eb3b80-6c69-41b8-94ef-b6630c365d20" />



