### PR TITLE
Keep media session synced in screensaver

### DIFF
--- a/dist/homeii-music-flow.js
+++ b/dist/homeii-music-flow.js
@@ -38872,13 +38872,15 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
   _syncNowPlayingUI() {
     this._syncSleepTimerState();
     this._syncNightModeUi();
+    const player = this._getSelectedPlayer();
+    const currentQueueItem = this._state.maQueueState?.current_item || null;
     if (this._state.screensaverOpen) {
       this._syncScreensaverDynamicArtwork();
       this._syncScreensaverUi();
       this._syncAmbientLightForCurrentMedia("screensaver");
+      this._syncLocalSendspinMediaSession(player, currentQueueItem);
       return;
     }
-    const player = this._getSelectedPlayer();
     if (!player) {
       this._syncControlRoomUi();
       this._resetLocalSendspinMediaSession();
@@ -39049,7 +39051,6 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
       this._state.mobileArtBrowseOffset = 0;
     }
     const stack = this._mobileArtStackItems();
-    const currentQueueItem = this._state.maQueueState?.current_item || null;
     const currentMedia = currentQueueItem?.media_item || {};
     const hasPendingPlay = Number(this._state.mobileQueuePlayPendingUntil || 0) > Date.now();
     const playerUri = String(player.attributes.media_content_id || "").trim();

--- a/src/homeii-music-flow.js
+++ b/src/homeii-music-flow.js
@@ -38872,13 +38872,15 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
   _syncNowPlayingUI() {
     this._syncSleepTimerState();
     this._syncNightModeUi();
+    const player = this._getSelectedPlayer();
+    const currentQueueItem = this._state.maQueueState?.current_item || null;
     if (this._state.screensaverOpen) {
       this._syncScreensaverDynamicArtwork();
       this._syncScreensaverUi();
       this._syncAmbientLightForCurrentMedia("screensaver");
+      this._syncLocalSendspinMediaSession(player, currentQueueItem);
       return;
     }
-    const player = this._getSelectedPlayer();
     if (!player) {
       this._syncControlRoomUi();
       this._resetLocalSendspinMediaSession();
@@ -39049,7 +39051,6 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
       this._state.mobileArtBrowseOffset = 0;
     }
     const stack = this._mobileArtStackItems();
-    const currentQueueItem = this._state.maQueueState?.current_item || null;
     const currentMedia = currentQueueItem?.media_item || {};
     const hasPendingPlay = Number(this._state.mobileQueuePlayPendingUntil || 0) > Date.now();
     const playerUri = String(player.attributes.media_content_id || "").trim();


### PR DESCRIPTION
### Summary

This PR fixes a small sequence in the previous PR affecting the Sendspin media session integration on the macOS menubar.

### Fix

- Corrected the sequence in which active media session functions are called
- Ensured media session metadata is resynchronized on every track change
- Improved synchronization consistency between:
    - playback state
    - media metadata
    - active Sendspin session state

### Result

- Reliable media session visibility in the macOS menubar
- Proper metadata updates during song changes
- Improved playback state synchronization with the system media session API

Now I'm done for the rest of the week. You can reach out to me anytime.
