### PR TITLE
Fix Sendspin audio fallback in macOS native HA app

### DIFF
--- a/dist/sendspin-js/audio/scheduler.js
+++ b/dist/sendspin-js/audio/scheduler.js
@@ -426,14 +426,20 @@ export class AudioScheduler {
                 });
             }
             else {
-                this.streamDestination =
-                    this.audioContext.createMediaStreamDestination();
-                this.gainNode.connect(this.streamDestination);
-                audioElement.srcObject = this.streamDestination.stream;
-                audioElement.volume = 1.0;
-                audioElement.play().catch((e) => {
-                    console.warn("Sendspin: Audio autoplay blocked:", e);
-                });
+                if (typeof this.audioContext.createMediaStreamDestination === "function") {
+                    this.streamDestination =
+                        this.audioContext.createMediaStreamDestination();
+                    this.gainNode.connect(this.streamDestination);
+                    audioElement.srcObject = this.streamDestination.stream;
+                    audioElement.volume = 1.0;
+                    audioElement.play().catch((e) => {
+                        console.warn("Sendspin: Audio autoplay blocked:", e);
+                    });
+                }
+                else {
+                    console.warn("Sendspin: MediaStreamDestination is unavailable; falling back to direct AudioContext output.");
+                    this.gainNode.connect(this.audioContext.destination);
+                }
             }
         }
         this.updateVolume();

--- a/src/sendspin-js/audio/scheduler.js
+++ b/src/sendspin-js/audio/scheduler.js
@@ -426,14 +426,20 @@ export class AudioScheduler {
                 });
             }
             else {
-                this.streamDestination =
-                    this.audioContext.createMediaStreamDestination();
-                this.gainNode.connect(this.streamDestination);
-                audioElement.srcObject = this.streamDestination.stream;
-                audioElement.volume = 1.0;
-                audioElement.play().catch((e) => {
-                    console.warn("Sendspin: Audio autoplay blocked:", e);
-                });
+                if (typeof this.audioContext.createMediaStreamDestination === "function") {
+                    this.streamDestination =
+                        this.audioContext.createMediaStreamDestination();
+                    this.gainNode.connect(this.streamDestination);
+                    audioElement.srcObject = this.streamDestination.stream;
+                    audioElement.volume = 1.0;
+                    audioElement.play().catch((e) => {
+                        console.warn("Sendspin: Audio autoplay blocked:", e);
+                    });
+                }
+                else {
+                    console.warn("Sendspin: MediaStreamDestination is unavailable; falling back to direct AudioContext output.");
+                    this.gainNode.connect(this.audioContext.destination);
+                }
             }
         }
         this.updateVolume();


### PR DESCRIPTION
Since you mentioned that you want to push a new release soon, I would consider it important to fix this issue. I was dumb enough to make a visual review of the last PR without even confirming the audio stream was functional.

This fixes local Sendspin playback in the native Home Assistant app for macOS.

The macOS HA WebView provides an AudioContext, but does not support audioContext.createMediaStreamDestination(). HOMEii’s local Sendspin player previously assumed that API existed when using media-element output, which caused playback setup to throw before audio could be routed. Music Assistant still showed playback as active, and media metadata could appear in the macOS menu bar, but no sound was produced.

This change keeps the existing MediaStreamDestination -> audio.srcObject path when supported, and adds a fallback for WebViews where createMediaStreamDestination() is unavailable. In that case, Sendspin now connects the gain node directly to audioContext.destination.

Validated in the native Home Assistant macOS app:

Before: TypeError: this.audioContext.createMediaStreamDestination is not a function
After: Sendspin: MediaStreamDestination is unavailable; falling back to direct AudioContext output.
Local Sendspin playback now produces sound

npm run build
npm run check with existing lint warnings only
90 tests passing