### PR TITLE
Artwork cache: scale LRU cap by performance_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Artwork cache: the LRU cap on the decoded-artwork bitmap cache is now scaled by `performance_profile` rather than hard-coded at 180. The `full` profile is intentionally left at 180 so default users see no change. Lighter profiles get tighter caps to recover idle memory on kiosk / low-RAM devices: `high` = 120, `low` = 60, `ultra_lite` = 30. The cap selector is a new `maxDecodedArtworkCache(profile)` in `src/core/state/derived.js` that falls back to the `full` value for unknown or empty profile strings, so existing behavior is preserved. Verified end-to-end on a real card instance: pre-filling 50 entries, switching to `ultra_lite`, and triggering one decode evicts down to exactly 30.
+
 ### Added
 
 - Danish (`da`) localization. Adds `src/localization/da.js` with all 925 keys translated via DeepL using a glossary that locks brand names (HOMEii Flow, Music Assistant, Sendspin, Spotify, etc.) and music-domain terms (Library, Queue, Playlist, etc.) to consistent renderings. Registered in `src/localization/index.js` and exposed as "Dansk" in the language picker. Native Danish speaker review by submitter (Danish household using the card daily for kids' room dashboards).

--- a/dist/core/state/derived.js
+++ b/dist/core/state/derived.js
@@ -40,6 +40,24 @@ export function performanceUltraLiteEnabled(state) {
   return performanceProfile(state) === "ultra_lite";
 }
 
+// Decoded artwork bitmap cache size by performance profile. Each entry pins
+// a Blob/Image of roughly 50-100 KB in memory, so the cap is the dominant
+// knob for the card's idle artwork-memory footprint on memory-constrained
+// devices (kitchen kiosks, low-RAM phones, embedded HA dashboards).
+// The "full" profile is intentionally left at today's value so existing
+// users see no change unless they explicitly opt into a lighter profile.
+const DECODED_ARTWORK_CACHE_CAPS = Object.freeze({
+  full: 180,
+  high: 120,
+  low: 60,
+  ultra_lite: 30,
+});
+
+export function maxDecodedArtworkCache(profile) {
+  const normalized = String(profile || "").trim().toLowerCase();
+  return DECODED_ARTWORK_CACHE_CAPS[normalized] ?? DECODED_ARTWORK_CACHE_CAPS.full;
+}
+
 export function mobileDynamicThemeMode(state) {
   const profile = performanceProfile(state);
   if (profile === "low" || profile === "ultra_lite") return "off";

--- a/dist/homeii-music-flow.js
+++ b/dist/homeii-music-flow.js
@@ -22344,6 +22344,16 @@ function performanceModeEnabled(state) {
 function performanceUltraLiteEnabled(state) {
   return performanceProfile(state) === "ultra_lite";
 }
+const DECODED_ARTWORK_CACHE_CAPS = Object.freeze({
+  full: 180,
+  high: 120,
+  low: 60,
+  ultra_lite: 30
+});
+function maxDecodedArtworkCache(profile) {
+  const normalized = String(profile || "").trim().toLowerCase();
+  return DECODED_ARTWORK_CACHE_CAPS[normalized] ?? DECODED_ARTWORK_CACHE_CAPS.full;
+}
 function mobileDynamicThemeMode(state) {
   const profile = performanceProfile(state);
   if (profile === "low" || profile === "ultra_lite") return "off";
@@ -30119,7 +30129,8 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
       const markReady = () => {
         this._decodedArtworkUrls.add(normalized);
         this._decodedArtworkImages.set(normalized, img);
-        while (this._decodedArtworkUrls.size > 180) {
+        const cap = maxDecodedArtworkCache(this._performanceProfile());
+        while (this._decodedArtworkUrls.size > cap) {
           const oldest = this._decodedArtworkUrls.values().next().value;
           if (!oldest) break;
           this._decodedArtworkUrls.delete(oldest);

--- a/src/core/state/derived.js
+++ b/src/core/state/derived.js
@@ -40,6 +40,24 @@ export function performanceUltraLiteEnabled(state) {
   return performanceProfile(state) === "ultra_lite";
 }
 
+// Decoded artwork bitmap cache size by performance profile. Each entry pins
+// a Blob/Image of roughly 50-100 KB in memory, so the cap is the dominant
+// knob for the card's idle artwork-memory footprint on memory-constrained
+// devices (kitchen kiosks, low-RAM phones, embedded HA dashboards).
+// The "full" profile is intentionally left at today's value so existing
+// users see no change unless they explicitly opt into a lighter profile.
+const DECODED_ARTWORK_CACHE_CAPS = Object.freeze({
+  full: 180,
+  high: 120,
+  low: 60,
+  ultra_lite: 30,
+});
+
+export function maxDecodedArtworkCache(profile) {
+  const normalized = String(profile || "").trim().toLowerCase();
+  return DECODED_ARTWORK_CACHE_CAPS[normalized] ?? DECODED_ARTWORK_CACHE_CAPS.full;
+}
+
 export function mobileDynamicThemeMode(state) {
   const profile = performanceProfile(state);
   if (profile === "low" || profile === "ultra_lite") return "off";

--- a/src/homeii-music-flow.js
+++ b/src/homeii-music-flow.js
@@ -42,6 +42,7 @@ import {
   mobileCompactModeEnabled as homeiiMobileCompactModeEnabled,
   mobileCompactWidgetMode as homeiiMobileCompactWidgetMode,
   mobileDynamicThemeMode as homeiiMobileDynamicThemeMode,
+  maxDecodedArtworkCache as homeiiMaxDecodedArtworkCache,
   mobileShowUpNextEnabled as homeiiMobileShowUpNextEnabled,
   normalizeSettingsSource as homeiiNormalizeSettingsSource,
   performanceModeEnabled as homeiiPerformanceModeEnabled,
@@ -5022,7 +5023,8 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
       const markReady = () => {
         this._decodedArtworkUrls.add(normalized);
         this._decodedArtworkImages.set(normalized, img);
-        while (this._decodedArtworkUrls.size > 180) {
+        const cap = homeiiMaxDecodedArtworkCache(this._performanceProfile());
+        while (this._decodedArtworkUrls.size > cap) {
           const oldest = this._decodedArtworkUrls.values().next().value;
           if (!oldest) break;
           this._decodedArtworkUrls.delete(oldest);

--- a/tests/state-derived.test.js
+++ b/tests/state-derived.test.js
@@ -4,6 +4,7 @@ import {
   backgroundMotionAmount,
   backgroundMotionEnabled,
   isCompactTileMode,
+  maxDecodedArtworkCache,
   mobileBackgroundMotionMode,
   mobileCompactModeEnabled,
   mobileCompactWidgetMode,
@@ -71,5 +72,21 @@ describe("state derived helpers", () => {
     expect(mobileBackgroundMotionMode({ performanceProfile: "high", mobileBackgroundMotionMode: "extreme" })).toBe("subtle");
     expect(mobileDynamicThemeMode({ performanceProfile: "ultra_lite", mobileDynamicThemeMode: "strong" })).toBe("off");
     expect(mobileBackgroundMotionMode({ performanceProfile: "ultra_lite", mobileBackgroundMotionMode: "strong" })).toBe("off");
+  });
+
+  it("scales decoded-artwork cache cap by performance profile", () => {
+    // full is intentionally unchanged at 180 to preserve existing behavior
+    // for default users. Lighter profiles get tighter caps to recover memory
+    // on kiosk / low-RAM devices.
+    expect(maxDecodedArtworkCache("full")).toBe(180);
+    expect(maxDecodedArtworkCache("high")).toBe(120);
+    expect(maxDecodedArtworkCache("low")).toBe(60);
+    expect(maxDecodedArtworkCache("ultra_lite")).toBe(30);
+    // Robust to whitespace and case
+    expect(maxDecodedArtworkCache(" Ultra_Lite ")).toBe(30);
+    // Unknown / empty / null fall back to the full cap (no surprise reductions)
+    expect(maxDecodedArtworkCache("")).toBe(180);
+    expect(maxDecodedArtworkCache(null)).toBe(180);
+    expect(maxDecodedArtworkCache("nonsense")).toBe(180);
   });
 });


### PR DESCRIPTION
 Closes #50

  Replaces the hard-coded `180` in `_decodeArtworkUrl`'s eviction loop with a profile-scaled cap. Default users see no change (`full` profile stays at 180). Lighter profiles get tighter caps so users who
  explicitly opt into them recover memory.
  
  No rush on this one — happy for you to queue it up behind the current 5.8.2 beta hotfix cycle and any earlier PRs, same as #49. The change is small and isolated; merge order is entirely your call.

  ## Caps per profile

  - **full** — 180 (unchanged from today; default users see no change)
  - **high** — 120
  - **low** — 60
  - **ultra_lite** — 30
  - **unknown / empty profile** — falls back to 180 (no surprise reductions)

  ## What this caps (and what it doesn't)

  The cap only affects the *pre-decoded* artwork path — the in-card `Map`/`Set` that pins decoded bitmaps for smooth transitions. That covers:

  - Now-playing big artwork
  - Queue artwork (visible next/prev)
  - Ambient / backdrop art
  - History strip (recently played)
  - Active-player chip icon
  - Prefetched upcoming tracks

  touching browsing UX.

  ## On placement

  The new `maxDecodedArtworkCache(profile)` helper lives in `src/core/state/derived.js` right next to `performanceProfile`, alongside the other profile-scaled helpers (`mobileDynamicThemeMode`,
  `mobileBackgroundMotionMode`, `backgroundMotionAmount`) that already follow the same pattern: take state/profile, return a derived value. The cap constants live alongside the function in the same file so
  the relationship is immediately obvious to anyone reading the code. No new module or file is introduced. The eviction loop in `src/homeii-music-flow.js` is a 3-line change: one import alias, one local
  variable replacing the magic `180`, and one call site.

  ## Tests

  `tests/state-derived.test.js` gains a new test block with 8 assertions for `maxDecodedArtworkCache`:

  - Each known profile returns the right number
  - Whitespace and case are normalized (e.g. `" Ultra_Lite " → 30`)
  - Empty, `null`, and unknown profile strings fall back to `full` (180)

  Beyond the unit test, I validated the full eviction path end-to-end on a real card instance with real Music Assistant + Spotify in a dev HA. For each profile I pre-filled the cache above its cap and
  triggered one decode:

  - `full` — 200 entries pre-filled, decoded one URL, cache trimmed to **180** ✓
  - `high` — 140 → **120** ✓
  - `low` — 80 → **60** ✓
  - `ultra_lite` — 50 → **30** ✓
  - `nonsense` (fallback) — 200 → **180** ✓

  Repeated the `low` test with a real `https://i.scdn.co/...` Spotify URL fed through `_decodeArtworkUrl`: cache trimmed from 65 to 60, real URL preserved as the most-recent entry, oldest fake entries
  evicted. Map and Set stay in sync after every eviction.

  All 135 tests pass. ESLint clean. Vite production build clean.

  ## Note for the maintainer

  I'd suggest considering lowering `full` to ~60 in a future release once `low`/`ultra_lite` users have shipped some feedback. 180 was generous for the realistic working set on any single surface and the
  user-visible cost of a small re-decode is negligible thanks to HTTP caching. Kept at 180 in this PR specifically to avoid mixing a behavior change with this profile-scaling change — that's a separate
  decision for you to make on your timeline.

  ## Files touched

  - `src/core/state/derived.js` — new `maxDecodedArtworkCache(profile)` + cap constants
  - `src/homeii-music-flow.js` — import alias + use the selector in the eviction loop
  - `tests/state-derived.test.js` — 8 new assertions
  - `CHANGELOG.md` — Unreleased entry
  - `dist/` — rebuilt