### PR TITLE
Performance: scale low and ultra_lite profiles to actually reduce GPU…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Performance: `low` and `ultra_lite` profiles now eliminate `backdrop-filter` on always-visible UI controls (transport bar buttons, mobile art FABs, side buttons, source badges, fallback disc, control-room close, empty-quick-card buttons, player-focus button). Each `backdrop-filter` forces the GPU compositor to render and blur the backdrop behind the element every frame, even when the card is idle and JS is doing nothing. Substituting solid semi-transparent backgrounds with matching border colors preserves the layered look while removing the dominant idle GPU cost on weak hardware. Measured on a dev HA dashboard with no music playing, no interaction, 60 fps stable: total Chrome CPU dropped from ~148% sustained on `full` to ~77% on `low` (-48%) and ~60% on `ultra_lite` (-59%). `full` and `high` unchanged — default users see no change. Refs #52.
+
 ### Added
 
 - Danish (`da`) localization. Adds `src/localization/da.js` with all 925 keys translated via DeepL using a glossary that locks brand names (HOMEii Flow, Music Assistant, Sendspin, Spotify, etc.) and music-domain terms (Library, Queue, Playlist, etc.) to consistent renderings. Registered in `src/localization/index.js` and exposed as "Dansk" in the language picker. Native Danish speaker review by submitter (Danish household using the card daily for kids' room dashboards).

--- a/dist/homeii-music-flow.js
+++ b/dist/homeii-music-flow.js
@@ -45336,6 +45336,54 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
 .card.performance-ultra-lite .screensaver-voice-btn.listening::after{
   display:none!important;
 }
+/* Low + Ultra Lite: eliminate backdrop-filter on always-visible UI
+   controls. Each backdrop-filter forces the compositor to render and
+   blur the backdrop behind the element every frame, even at idle.
+   Substituting solid semi-transparent backgrounds preserves the layered
+   look while removing the dominant GPU cost on weak hardware (kiosks,
+   RPi). Applied to .performance-lite so both low and ultra_lite
+   benefit; ultra_lite keeps its existing additional opacity tweaks. */
+.card.performance-lite .player-focus,
+.card.performance-lite .mobile-art-fab,
+.card.performance-lite .side-btn,
+.card.performance-lite .main-btn,
+.card.performance-lite .source-badge,
+.card.performance-lite .fallback-disc,
+.card.performance-lite .control-room-close,
+.card.performance-lite .empty-quick-card{
+  backdrop-filter:none!important;
+  -webkit-backdrop-filter:none!important;
+}
+.card.performance-lite .player-focus,
+.card.performance-lite .mobile-art-fab,
+.card.performance-lite .side-btn,
+.card.performance-lite .main-btn,
+.card.performance-lite .control-room-close,
+.card.performance-lite .empty-quick-card{
+  background:rgba(18,22,30,.78)!important;
+  border-color:rgba(255,255,255,.16)!important;
+}
+.card.performance-lite .source-badge{
+  background:rgba(18,22,30,.85)!important;
+}
+.card.performance-lite .fallback-disc{
+  background:rgba(18,22,30,.78)!important;
+}
+.theme-light.card.performance-lite .player-focus,
+.theme-light.card.performance-lite .mobile-art-fab,
+.theme-light.card.performance-lite .side-btn,
+.theme-light.card.performance-lite .main-btn,
+.theme-light.card.performance-lite .control-room-close,
+.theme-light.card.performance-lite .empty-quick-card{
+  background:rgba(248,250,253,.86)!important;
+  border-color:rgba(123,139,164,.22)!important;
+}
+.theme-light.card.performance-lite .source-badge{
+  background:rgba(248,250,253,.92)!important;
+}
+.theme-light.card.performance-lite .fallback-disc{
+  background:rgba(248,250,253,.86)!important;
+}
 
 .menu-sheet,
 .queue-action-sheet,

--- a/src/homeii-music-flow.js
+++ b/src/homeii-music-flow.js
@@ -20325,6 +20325,54 @@ class HomeiiMusicFlowBaseCard extends HomeiiBaseMusicCard {
 .card.performance-ultra-lite .screensaver-voice-btn.listening::after{
   display:none!important;
 }
+/* Low + Ultra Lite: eliminate backdrop-filter on always-visible UI
+   controls. Each backdrop-filter forces the compositor to render and
+   blur the backdrop behind the element every frame, even at idle.
+   Substituting solid semi-transparent backgrounds preserves the layered
+   look while removing the dominant GPU cost on weak hardware (kiosks,
+   RPi). Applied to .performance-lite so both low and ultra_lite
+   benefit; ultra_lite keeps its existing additional opacity tweaks. */
+.card.performance-lite .player-focus,
+.card.performance-lite .mobile-art-fab,
+.card.performance-lite .side-btn,
+.card.performance-lite .main-btn,
+.card.performance-lite .source-badge,
+.card.performance-lite .fallback-disc,
+.card.performance-lite .control-room-close,
+.card.performance-lite .empty-quick-card{
+  backdrop-filter:none!important;
+  -webkit-backdrop-filter:none!important;
+}
+.card.performance-lite .player-focus,
+.card.performance-lite .mobile-art-fab,
+.card.performance-lite .side-btn,
+.card.performance-lite .main-btn,
+.card.performance-lite .control-room-close,
+.card.performance-lite .empty-quick-card{
+  background:rgba(18,22,30,.78)!important;
+  border-color:rgba(255,255,255,.16)!important;
+}
+.card.performance-lite .source-badge{
+  background:rgba(18,22,30,.85)!important;
+}
+.card.performance-lite .fallback-disc{
+  background:rgba(18,22,30,.78)!important;
+}
+.theme-light.card.performance-lite .player-focus,
+.theme-light.card.performance-lite .mobile-art-fab,
+.theme-light.card.performance-lite .side-btn,
+.theme-light.card.performance-lite .main-btn,
+.theme-light.card.performance-lite .control-room-close,
+.theme-light.card.performance-lite .empty-quick-card{
+  background:rgba(248,250,253,.86)!important;
+  border-color:rgba(123,139,164,.22)!important;
+}
+.theme-light.card.performance-lite .source-badge{
+  background:rgba(248,250,253,.92)!important;
+}
+.theme-light.card.performance-lite .fallback-disc{
+  background:rgba(248,250,253,.86)!important;
+}
 
 .menu-sheet,
 .queue-action-sheet,


### PR DESCRIPTION
Refs #52

  ## This is a suggestion, not a fix

  This PR changes the visual look-and-feel of the `low` and `ultra_lite` profiles — the live-blur "glassmorphism" on the always-visible UI controls becomes a flat matte semi-transparent surface. That is a
  design call, not just a perf call, and you may have intentional reasons to keep the glass look on those profiles. If so, please feel free to close this and I'll adjust or drop it.

  I'm filing it because the measurements from #52 suggested the existing setting wasn't giving kiosk-class users a meaningful CPU reduction, and the cheapest visual lever (drop live-blur on always-visible
  controls) has a large effect. Whether that tradeoff is the right one is your call.

  ## What the patch does

  - Adds CSS gates under `.performance-lite` (covers both `low` and `ultra_lite`) that eliminate `backdrop-filter` on always-visible UI controls.
  - Substitutes solid semi-transparent `rgba()` backgrounds with matching border colors so the layered look is preserved without the per-frame GPU compositor cost.
  - `full` and `high` are untouched. Default users see no difference.

  ## Surfaces gated

  - `.player-focus`
  - `.mobile-art-fab`
  - `.side-btn`, `.main-btn`
  - `.source-badge`
  - `.fallback-disc`
  - `.control-room-close`
  - `.empty-quick-card`

  Each gets `backdrop-filter: none` plus a solid `rgba()` background substitute. Both dark and light theme variants included.

  ## Measurements (the case for the tradeoff)

  Methodology: dev HA at localhost:9123, Playwright Chromium, no music playing, no interaction, 60 fps stable, JS idle (0 long tasks, 0 app-scheduled RAFs). Total Chrome CPU sampled at 1 Hz via `ps`, 8 second
   sustained window per profile after a 1.5 s settle.

  Before this patch:

  - full: ~174% Chrome CPU sustained
  - ultra_lite: ~139% (essentially the same as full — the setting was not delivering CPU savings on the always-visible surfaces)


  - full: ~148% (unchanged, day-to-day variance)
  - high: ~131% (unchanged)
  - low: ~77% (-48% vs full)
  - ultra_lite: ~60% (-59% vs full, below the empty-HA-dashboard baseline of ~62%)

  Visible `backdrop-filter` count (computed-style audit on visible / painted elements only):

  - full: 19
  - high: 18
  - low: 0
  - ultra_lite: 0

  ## Visual outcome

  `ultra_lite` and `low` look matte: solid semi-transparent buttons instead of live-blur glass. Layout, spacing, text, and iconography are unchanged. Whether this is acceptable for those profiles is exactly
  the question this PR exists to ask you.

  Happy to:

  - Drop the change on `low` and only keep it on `ultra_lite` (smaller blast radius, same gradient narrative).
  - Adjust which selectors are gated.
  - Adjust the substitute background opacities to be closer to the original glass look.
  - Withdraw entirely if you'd rather keep the glass on all profiles.

  ## What is NOT changed

  - `full` and `high` profiles — the visual identity for default users is identical.
  - The existing `performance-lite` / `performance-ultra-lite` rules in the codebase — this patch only appends new selectors.
  - Any JS, runtime behavior, settings UI, or persistence.

  ## Tests

  - `npm run check` — all 134 tests pass.
  - `npm run build` — clean (+48 lines source, +48 lines dist).
  - Manual: switched profile via Settings UI on dev HA, layout intact, controls readable, no visible regressions on the empty / idle dashboard surface.

  ## Out of scope here

  - Other items in #52 (auto-downgrade on slow hardware, `contain: paint` on idle, duplicate artwork fetches) are not in this patch.
  - No rush on merge — happy to queue behind any beta hotfix work you have in flight.