### PR TITLE
Fetch full Queue Actions snapshots for large queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ type: custom:homeii-music-flow
 - If Home Assistant is opened locally over `http://`, a local `http://` Music Assistant URL is usually fine and HOMEii Flow will use `ws://`.
 - Mobile browsers can pause audio and WebSocket work when the app is backgrounded or the phone is locked. HOMEii Flow remembers the active "This device" intent during the current app/browser session and reconnects when the dashboard becomes active again.
 - Optional: a configured `tts.*` entity for text-to-speech announcements.
+- Optional: [Music Assistant Queue Actions](https://github.com/droans/mass_queue) for complete queue lists. Home Assistant's built-in Music Assistant queue action may expose only the current and next items.
 - Optional but recommended: correct Home Assistant internal/external URLs, especially for phones, tablets, and remote access.
 
 ## First Startup Checklist
@@ -172,6 +173,7 @@ If the card loads but feels incomplete, check these first:
 - If you use HOMEii Flow remotely, confirm Home Assistant external/internal URLs are correct. For Direct Music Assistant features, `ma_url` should be reachable from the browser you are using, not only from the local network.
 - If artwork is missing only when away from home, prefer Home Assistant-accessible artwork paths or expose Music Assistant through a secure reachable URL. HOMEii Flow now avoids private-network artwork URLs when the browser is remote, but a local-only MA URL can still limit Direct API artwork.
 - If no players are shown, check Music Assistant player exposure and remove overly strict pinned-player filters from the card settings.
+- If the queue shows only the current and next items, install and configure Music Assistant Queue Actions. HOMEii Flow detects its `mass_queue.get_queue_items` action automatically.
 - Optional automation helper: create an `input_text`, then set `active_player_helper_entity` so automations can read the current HOMEii Flow target.
 
 ## Active Player Helper

--- a/dist/core/base-music-card.js
+++ b/dist/core/base-music-card.js
@@ -9219,7 +9219,7 @@ export function createHomeiiBaseMusicCard({
 
     _getNowPlayingQueueItems() {
       const currentIndex = this._state.maQueueState?.current_index ?? -1;
-      return (this._state.queueItems || []).filter((item) => (item.sort_index ?? 0) >= currentIndex).slice(0, 100);
+      return (this._state.queueItems || []).filter((item) => (item.sort_index ?? 0) >= currentIndex).slice(0, 1000);
     }
 
     _queuePanelHtml(queueItems = []) {
@@ -10417,8 +10417,8 @@ export function createHomeiiBaseMusicCard({
           service: "get_queue_items",
           service_data: {
             entity: player.entity_id,
-            limit_before: 20,
-            limit_after: 120,
+            limit: 1000,
+            offset: 0,
           },
           return_response: true,
         });

--- a/dist/homeii-music-flow.js
+++ b/dist/homeii-music-flow.js
@@ -18900,7 +18900,7 @@ function createHomeiiBaseMusicCard({
     }
     _getNowPlayingQueueItems() {
       const currentIndex = this._state.maQueueState?.current_index ?? -1;
-      return (this._state.queueItems || []).filter((item) => (item.sort_index ?? 0) >= currentIndex).slice(0, 100);
+      return (this._state.queueItems || []).filter((item) => (item.sort_index ?? 0) >= currentIndex).slice(0, 1e3);
     }
     _queuePanelHtml(queueItems = []) {
       if (!queueItems.length) {
@@ -19948,8 +19948,8 @@ function createHomeiiBaseMusicCard({
           service: "get_queue_items",
           service_data: {
             entity: player.entity_id,
-            limit_before: 20,
-            limit_after: 120
+            limit: 1e3,
+            offset: 0
           },
           return_response: true
         });

--- a/src/core/base-music-card.js
+++ b/src/core/base-music-card.js
@@ -9219,7 +9219,7 @@ export function createHomeiiBaseMusicCard({
 
     _getNowPlayingQueueItems() {
       const currentIndex = this._state.maQueueState?.current_index ?? -1;
-      return (this._state.queueItems || []).filter((item) => (item.sort_index ?? 0) >= currentIndex).slice(0, 100);
+      return (this._state.queueItems || []).filter((item) => (item.sort_index ?? 0) >= currentIndex).slice(0, 1000);
     }
 
     _queuePanelHtml(queueItems = []) {
@@ -10417,8 +10417,8 @@ export function createHomeiiBaseMusicCard({
           service: "get_queue_items",
           service_data: {
             entity: player.entity_id,
-            limit_before: 20,
-            limit_after: 120,
+            limit: 1000,
+            offset: 0,
           },
           return_response: true,
         });

--- a/tests/runtime-baseline.test.js
+++ b/tests/runtime-baseline.test.js
@@ -1303,6 +1303,60 @@ describe("runtime baseline", () => {
     expect(snapshot.items[0].media_item.name).toBe("Track A");
   });
 
+  it("loads and displays large Queue Actions snapshots without the previous 100-item cap", async () => {
+    await import("../src/homeii-music-flow.js?runtime-mass-queue-large-snapshot-baseline");
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+
+    const CardCtor = globalThis.customElements.get("homeii-music-flow");
+    const card = new CardCtor();
+    const player = {
+      entity_id: "media_player.office",
+      attributes: {
+        media_title: "Track 101",
+        media_artist: "Artist 101",
+      },
+    };
+    const items = Array.from({ length: 691 }, (_, index) => ({
+      queue_item_id: `queue-${index}`,
+      sort_index: index,
+      media_item: {
+        uri: `spotify://track/${index}`,
+        name: `Track ${index}`,
+        media_type: "track",
+        artists: [{ name: `Artist ${index}` }],
+      },
+    }));
+    const sendMessagePromise = vi.fn(async () => ({
+      response: {
+        queue_state: { current_index: 101, items: items.length },
+        items,
+      },
+    }));
+    card._hass = { connection: { sendMessagePromise } };
+    card._hasMassQueueService = vi.fn(() => true);
+
+    const snapshot = await card._fetchMassQueueItemsSnapshot(player);
+
+    expect(sendMessagePromise).toHaveBeenCalledWith({
+      type: "call_service",
+      domain: "mass_queue",
+      service: "get_queue_items",
+      service_data: {
+        entity: player.entity_id,
+        limit: 1000,
+        offset: 0,
+      },
+      return_response: true,
+    });
+    expect(snapshot.items).toHaveLength(691);
+
+    card._state.queueItems = snapshot.items;
+    card._state.maQueueState = snapshot.state;
+    expect(card._getNowPlayingQueueItems()).toHaveLength(590);
+    expect(card._getNowPlayingQueueItems()[0].sort_index).toBe(101);
+  });
+
   it("uses direct Music Assistant queue snapshots only after Home Assistant queue lookups fail", async () => {
     await import("../src/homeii-music-flow.js?runtime-queue-direct-fallback-baseline");
     await Promise.resolve();


### PR DESCRIPTION
## Summary

- Request up to 1,000 queue entries from `mass_queue.get_queue_items` using `limit` and `offset`.
- Increase the Now Playing queue display limit from 100 to 1,000 entries.
- Document Music Assistant Queue Actions as the optional integration needed for complete queue lists.
- Add regression coverage for large queues.

## Why

Home Assistant’s built-in Music Assistant queue action may return only the current and next items.

Music Assistant Queue Actions exposes the complete queue, but HOMEii Flow requested only 20 previous and 120 upcoming entries. The Now Playing panel then applied a separate 100-entry display cap.

For example, requesting the first 500 entries from a 691-track queue at position 101 left exactly 399 current-and-upcoming entries. This matched the behaviour observed in a live installation.

## Testing

- `npm run check`
- `npm run build`
- Added a regression test using a 691-track queue at position 101.
- The test confirms all 691 records are fetched and the expected 590 current-and-upcoming tracks remain visible.

Test environment:

- Home Assistant Core 2026.8.3
- Music Assistant 2.9.13
- Music Assistant Queue Actions 0.10.3
- HOMEii Music Flow 5.9.3 installed through HACS

This supports queues of up to 1,000 items. Larger queues would require pagination in a future change.

Related to #68.